### PR TITLE
Fixes exception if bitlen is not set in call parameters

### DIFF
--- a/CryptoMobile/CM.py
+++ b/CryptoMobile/CM.py
@@ -360,6 +360,7 @@ class AES_3GPP(object):
         #
         if bitlen is None:
             bitlen = 8*len(data_in)
+            lastbits = None
         else:
             lastbits = (8-(bitlen%8))%8
             blen = bitlen >> 3


### PR DESCRIPTION

EEA2 fails if called with the default bitlen.  This sets it to default at None so the following if statement doesn't throw.