### PR TITLE
Fix pycrypto usage of AES CTR mode

### DIFF
--- a/CryptoMobile/AES.py
+++ b/CryptoMobile/AES.py
@@ -41,6 +41,7 @@ from .utils import *
 # try to load pycrypto
 try:
     from Crypto.Cipher import AES as AES_pycrypto
+    from Crypto.Util import Counter_pycrypto
 except ImportError:
     _with_pycrypto = False
 else:
@@ -142,14 +143,7 @@ class AES_CTR_pycrypto(object):
         self.aes = AES_pycrypto.new(
             key,
             AES_pycrypto.MODE_CTR,
-            counter=self.__cnt)
-    
-    def __cnt(self):
-        cnt = self.cnt_hi + pack('>Q', self.cnt_lo)
-        self.cnt_lo += 1
-        if self.cnt_lo == MAX_UINT64:
-            self.cnt_lo = 0
-        return cnt
+            counter=Counter_pycrypto.new(64, prefix=self.cnt_hi, initial_value=0))
     
     def encrypt(self, data):
         """encrypt / decrypt data with the key and IV set at initialization"""


### PR DESCRIPTION
The counter parameter in pycrypto changed from being a callback, to an object describing how to do the counting.